### PR TITLE
contracts,test: Upgrade required sol compiler version to 0.4.18 and a…

### DIFF
--- a/contracts/Creatable.sol
+++ b/contracts/Creatable.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 
 // Contract creators may be rewarded in the future with bounties or other special privileges.  Additionally

--- a/contracts/Linkable.sol
+++ b/contracts/Linkable.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 
 /// @title Linkable

--- a/contracts/MarketCollateralPool.sol
+++ b/contracts/MarketCollateralPool.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./libraries/MathLib.sol";
 import "./tokens/MarketToken.sol";

--- a/contracts/MarketContract.sol
+++ b/contracts/MarketContract.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./Creatable.sol";
 import "./MarketCollateralPool.sol";

--- a/contracts/MarketContractRegistry.sol
+++ b/contracts/MarketContractRegistry.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./MarketContract.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 contract Migrations {
   address public owner;

--- a/contracts/libraries/MathLib.sol
+++ b/contracts/libraries/MathLib.sol
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 
 /// @title Math function library with overflow protection inspired by Open Zeppelin

--- a/contracts/libraries/OrderLib.sol
+++ b/contracts/libraries/OrderLib.sol
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./MathLib.sol";
 

--- a/contracts/oraclize/MarketContractOraclize.sol
+++ b/contracts/oraclize/MarketContractOraclize.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./oraclizeAPI.sol";
 import "../libraries/MathLib.sol";

--- a/contracts/oraclize/OraclizeQueryTest.sol
+++ b/contracts/oraclize/OraclizeQueryTest.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./oraclizeAPI.sol";
 import "../libraries/MathLib.sol";

--- a/contracts/oraclize/TestableMarketContractOraclize.sol
+++ b/contracts/oraclize/TestableMarketContractOraclize.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "./MarketContractOraclize.sol";
 

--- a/contracts/tokens/CollateralToken.sol
+++ b/contracts/tokens/CollateralToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "zeppelin-solidity/contracts/examples/SimpleToken.sol";
 

--- a/contracts/tokens/MarketToken.sol
+++ b/contracts/tokens/MarketToken.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "../Creatable.sol";
 import "zeppelin-solidity/contracts/token/StandardToken.sol";

--- a/test/TestCreatable.sol
+++ b/test/TestCreatable.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "truffle/Assert.sol";
 import "../contracts/Creatable.sol";

--- a/test/libraries/TestMathLib.sol
+++ b/test/libraries/TestMathLib.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "truffle/Assert.sol";
 import "../../contracts/libraries/MathLib.sol";

--- a/test/libraries/TestOrderLib.sol
+++ b/test/libraries/TestOrderLib.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "truffle/Assert.sol";
 import "../../contracts/libraries/OrderLib.sol";

--- a/test/tokens/TestMarketToken.sol
+++ b/test/tokens/TestMarketToken.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import "truffle/Assert.sol";
 import "../../contracts/tokens/MarketToken.sol";


### PR DESCRIPTION
Setting ^ before compiler version allows to use versions greater than 0.4.18 and less than 0.5.0.

@pelsasser this should help with issue: #45 but let's wait for Travis.
